### PR TITLE
Update to mobx3

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -21,11 +21,6 @@ for (var i = 0; i < STORE_SIZE; i++) {
     text: 'Item' + i,
     completed: false,
     id: i,
-    // reference to some other todo item, to similate
-    // having references to other objects in the state
-    other: i > 0
-      ? initialState[i - 1] 
-      : null
   });
 }
 

--- a/src/stores/appstate.js
+++ b/src/stores/appstate.js
@@ -35,7 +35,6 @@ export default class AppState {
       id: this.todos.length,
       text,
       completed: false,
-      other: null
     }
     this.todos.unshift(todo)
     return todo


### PR DESCRIPTION
@mweststrate, sadly, but as far as we don't enhance original objects, this kind of references leads to stack overflow on large arrays. (I don't see the way to fix this in mobx without keeping track of original-to-observable objects)